### PR TITLE
Handle empty bold sequences properly.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 
 def read(filename):
     with open(filename) as f:

--- a/term2md/term2md.py
+++ b/term2md/term2md.py
@@ -84,6 +84,8 @@ def compress_bold(out_parts):
 
         out.append(out_parts[i])
         i += 1
+    if out == ["**","**"]:
+        return []
     return out
         
 def convert_f(f):
@@ -156,18 +158,19 @@ def convert_f(f):
             if _is_control(part): continue
 
             stripped = part.strip()
-            if stripped != part and mode == BOLD:
-                out_parts.append(part[:part.find(stripped)])
-                out_parts.append("**")
-                out_parts.append(stripped)
-                out_parts.append("**")
-                out_parts.append(part[part.find(stripped)+len(stripped):])
-            elif mode == BOLD:
-                out_parts.append("**")
-                out_parts.append(part)
-                out_parts.append("**")
-            else:
-                out_parts.append(part)
+            if stripped != '':
+                if stripped != part and mode == BOLD:
+                    out_parts.append(part[:part.find(stripped)])
+                    out_parts.append("**")
+                    out_parts.append(stripped)
+                    out_parts.append("**")
+                    out_parts.append(part[part.find(stripped)+len(stripped):])
+                elif mode == BOLD:
+                    out_parts.append("**")
+                    out_parts.append(part)
+                    out_parts.append("**")
+                else:
+                    out_parts.append(part)
 
         mode = _final_mode(parts, in_mode)
 

--- a/tests/test_term2md.py
+++ b/tests/test_term2md.py
@@ -146,6 +146,9 @@ def test_compress_sequential_bold():
 def test_compress_bold_across_whitespace():
     assert compress_bold(["**","foo","**"," ","**","bar","**"]) == \
         ["**","foo"," ","bar","**"]
+
+def test_compress_bold_with_empty_string():
+    assert compress_bold(["**","**"]) == []
     
 def test_handle_red_on_nonleading_line():
     input = ["regular then \x1b[31mred\x1b[0m\n"]
@@ -155,4 +158,7 @@ def test_handle_bold_red_on_nonleading_line():
     input = ["regular then \x1b[1m\x1b[31mred\x1b[0m\x1b[0m\n"]
     assert convert(input) == ["regular then **red**\n"]
 
-    
+def test_empty_bold():
+    input = ["some input \x1b[1m\x1b[0mand done\n"]
+    assert convert(input) == ["some input and done\n"]
+


### PR DESCRIPTION
This occurs when there is a BOLD control sequence followed
immediately by a RESET. We were previously outputting `****`
for this (i.e. start bold, empty string, end bold) and now
this is just properly elided. Bugfix.